### PR TITLE
feat: use bind for `textarea` and `select`

### DIFF
--- a/src/lib/utils/checkbox.ts
+++ b/src/lib/utils/checkbox.ts
@@ -1,0 +1,64 @@
+export type CheckboxElement = HTMLInputElement & { node: { type: 'checkbox' | 'radio' } }
+
+function booleanCheckbox(v) {
+	if (v === 'true' || v === 'false')
+		return Boolean(v)
+	return v
+}
+
+export function setCheckbox(node: CheckboxElement, value: any) {
+	let compare = (v: any) => value === v
+	if (Array.isArray(value))
+		compare = v => value.indexOf(v) >= 0
+
+	if (
+		(node.getAttribute('value') === null && value === true)
+		|| compare(booleanCheckbox(node.value))
+	) {
+		node.checked = true
+		return
+	}
+	node.checked = false
+}
+
+export function formatCheckboxArray(value: unknown[]) {
+	value ??= []
+	if (!Array.isArray(value))
+		value = value === false || value === true ? [] : [value]
+	return value
+}
+
+function checkboxArray(node: CheckboxElement, add: boolean, existingValue: unknown[]) {
+	existingValue = formatCheckboxArray(existingValue)
+	const index = existingValue.indexOf(node.value as any)
+	if (index >= 0) {
+		if (!add)
+			existingValue.splice(index, 1)
+		return existingValue
+	}
+	if (add)
+		existingValue.push(node.value)
+	return existingValue
+}
+
+export function getCheckbox(node: CheckboxElement, existingValue: unknown[] | unknown) {
+	const hasValue = node.getAttribute('value') !== null
+	if (!hasValue)
+		return Boolean(node.checked)
+	if (node.checked) {
+		if (node.type.toUpperCase() === 'RADIO')
+			return booleanCheckbox(node.value)
+
+		if (hasValue) {
+			existingValue ??= []
+			return checkboxArray(node, true, existingValue as unknown[])
+		}
+		return Boolean(node.checked)
+	}
+	else if (node.type.toUpperCase() === 'CHECKBOX') {
+		if (hasValue) {
+			existingValue ??= []
+			return checkboxArray(node, false, existingValue as unknown[])
+		}
+	}
+}

--- a/src/lib/utils/node-type.ts
+++ b/src/lib/utils/node-type.ts
@@ -1,0 +1,16 @@
+import type { CheckboxElement } from './checkbox'
+
+export function isNodeDiv(node: HTMLElement): node is HTMLDivElement {
+	return node.tagName === 'DIV'
+}
+
+export function isNodeInput(node: HTMLElement): node is HTMLInputElement {
+	return node.tagName === 'INPUT'
+}
+
+export function isNodeCheckbox(node: HTMLElement): node is CheckboxElement {
+	if (!isNodeInput(node))
+		return false
+	const type = node.type.toUpperCase()
+	return type === 'CHECKBOX' || type === 'RADIO'
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,9 @@
 	let s: ValueStore<{ 
 		test: string
 		min: number
+		'multi-checkbox': string[]
+		checkbox: boolean
+		radio: string
 		nested: {
 			str: string
 			inside: {
@@ -31,6 +34,8 @@
 
 	onMount(async () => {
 		s.update(v => {
+			v.checkbox = true
+			v.radio = 'a'
 			v.test = 'herp'
 			v['nested'] = { ...(v['nested'] || { str:'' }), inside: { deep: '1st' } }
 			v['another'] = { nested: { 'some-text': 'A' } }
@@ -40,6 +45,9 @@
 		await sleep(750)
 		
 		s.update(v => {
+			v.checkbox = false
+			v.radio = 'b'
+			v['multi-checkbox'] = ['b', 'c']
 			v.test = 'derp'
 			v.nested.inside.deep = '2nd'
 			v.another.nested['some-text'] = 'B'
@@ -50,6 +58,9 @@
 		
 		t.set('slurp')
 		s.update(v => {
+			v.checkbox = true
+			v.radio = 'c'
+			v['multi-checkbox'] = []
 			v.nested.inside.deep = '3rd'
 			v.another.nested['some-text'] = 'C'
 			v.nested.str = 'str'
@@ -73,7 +84,7 @@
 <container>
 	
 	<I.Text bind={[s, s => s.text]}>Text</I.Text>
-	<I.Object bind:store={s} let:store let:value partial={{ nested: { str: 'Pre-defined value' } }} test={testAttribute} disabled={$s?.disableAll} >
+	<I.Object bind:store={s} let:store let:value partial={{ 'multi-checkbox': ['a', 'b', 'c'], nested: { str: 'Pre-defined value' } }} test={testAttribute} disabled={$s?.disableAll} >
 		<div style='flex-direction: row;'>
 			<label for='disableall'>Disable all</label>
 			<input id='disableall' type='checkbox' use:bind={[store, s => s.disableAll]} />
@@ -94,6 +105,18 @@
 					<I.Text name='{$t}'>{$t}</I.Text>
 					<!-- <h4>Dynamic bind - Does not work.</h4> -->
 					<!-- <I.Text bind={[store, s => s[$t || '']]}>bind {$t}</I.Text> -->
+				</div>
+
+				<div class="nested">
+					<input type='checkbox' use:store={'checkbox'} />
+					<input type='radio' use:store={'radio'} value='a' />
+					<input type='radio' use:store={'radio'} value='b' />
+					<input type='radio' use:store={'radio'} value='c' />
+					
+					<input type='checkbox' use:store={'multi-checkbox'} value='a' />
+					<input type='checkbox' use:store={'multi-checkbox'} value='b' />
+					<input type='checkbox' use:store={'multi-checkbox'} value='c' />
+					
 				</div>
 
 				<div class='nested'>

--- a/src/routes/test/+page.svelte
+++ b/src/routes/test/+page.svelte
@@ -31,6 +31,28 @@
 
 	<I.Object bind:store let:store test='123'>
 		
+		<input type='radio' use:store={'k'} value={false}>
+		<input type='radio' value='no' use:store={'k'}>
+		<input type='radio' value='yes' use:store={'k'}>
+		
+		<input type='checkbox' use:store={'c'}>
+		<input type='checkbox' value='no' use:store={'c'}>
+		<input type='checkbox' value='yes' use:store={'c'}>
+
+
+		<select use:store={'s'}>
+			<option value='a'>a</option>
+			<option value='b'>b</option>
+			<option value='c'>c</option>
+			<option value={1}>1</option>
+			<option value={2}>2</option>
+			<option value={3}>3</option>
+		</select>
+
+		<textarea use:store={'t'}>
+			Some text
+		</textarea>
+
 		<input use:store={'property'} />
 		<I.Array let:store let:value name='array'>
 


### PR DESCRIPTION
- feat: better `checkbox` and `radio` (https://github.com/Refzlund/svelte-object/issues/10)
- feat: use bind for `textarea` and `select` (https://github.com/Refzlund/svelte-object/issues/8)