### PR TITLE
feat: callable `valueStore` (aka `ValueStoreFn`)

### DIFF
--- a/src/lib/components/Array.svelte
+++ b/src/lib/components/Array.svelte
@@ -19,11 +19,7 @@
 	type O = InferArray<T>
 	type K = $$Generic
 	type P = $$Generic<string>
-
 	
-	
-
-
 	/** Initial value */
 	export let value: T | undefined = undefined
 	export const store = valueStoreArray<SvelteArray<O>>(value || [] as any)
@@ -61,4 +57,4 @@
 	
 </script>
 
-<slot {store} value={$store || []} attributes={$attributes}/>
+<slot svelteObject={obj} {store} value={$store || []} attributes={$attributes}/>

--- a/src/lib/components/Object.svelte
+++ b/src/lib/components/Object.svelte
@@ -6,6 +6,7 @@
 	import { svelteObject } from '$lib/utils/svelte-object'
 	import type { Bind, RecursivePartial } from '$lib/utils/types'
 	import onValidate from '$lib/utils/object-onValidate'
+	import { bind as bindUtil } from '$lib/bind'
 
 	type T = $$Generic<Record<any, any>>
 	type K = $$Generic
@@ -16,7 +17,14 @@
 	export let value: T | undefined = undefined
 	/** Initial value (value property is prioritized over this) */
 	export let partial: RecursivePartial<T> | undefined = undefined
-	export const store = createObjectStore(valueStore<T>((value || partial || {}) as T))
+	
+	export const store = valueStore(
+		(value || partial || {}) as T,
+		() => function bindStore(node: Parameters<typeof bindUtil>[0], property: string) {
+			return bindUtil(node, [store, s => s[property]])
+		}
+	)
+
 	export let 
 		name: string | number | undefined = undefined,
 		bind: Bind<T, K> | undefined = undefined,

--- a/src/lib/utils/object-onValidate.ts
+++ b/src/lib/utils/object-onValidate.ts
@@ -4,6 +4,7 @@ export default function onValidate(obj: SvelteObject) {
 	return ({ trigger: { blur, change }, error }) => {
 		const type = blur ? 'blur' : change ? 'change' : 'forced'
 		let valid = true
+		console.log(obj.stores)
 		for (let store of obj.stores)
 			if (!store.validate(type))
 				valid = false

--- a/src/lib/utils/value-store-array.ts
+++ b/src/lib/utils/value-store-array.ts
@@ -1,8 +1,9 @@
 import { get } from 'svelte/store'
 import { valueStore, type ValueStore } from '../value-store'
-import { createObjectStore, type ObjectStore } from './object-store'
+import type { ObjectStore } from './object-store'
 import { proxifyArray } from './proxify-array'
 import type { InferArray } from './types'
+import { bind } from '$lib/bind'
 
 type PartialOrT<T> = [T] extends [object] ? Partial<T> : T
 
@@ -14,7 +15,12 @@ export type ValueStoreArray<T extends Array<any>> = ObjectStore<T> & {
 }
 
 export default function valueStoreArray<T extends Array<any>>(initialValue: T): ValueStoreArray<T> {
-	const store = createObjectStore(valueStore(initialValue)) as ValueStoreArray<T> 
+	const store = valueStore(
+		initialValue,
+		() => function bindStore(node: Parameters<typeof bind>[0], property: string) {
+			return bind(node, [store, s => s[property]])
+		}
+	) as ValueStoreArray<T>
 	proxifyArray(store, get(store))
 
 	store.push = function push(item) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -196,10 +196,11 @@
 						<div class='nested'>
 							<I.Text name='min' min={20} value='giraffeisnice'>Min. 20 characters</I.Text>
 							<div class='nested'>
-								<I.Array name='array' let:value value={[ '', 'short' ]}>
+								<I.Array name='array' let:svelteObject let:value value={[ '', 'short' ]}>
 									{#each value as item, i}
 										<I.Text name='{i}' required min={7}>Required Min. 7 characters</I.Text>
 									{/each}
+									<button on:click={() => console.log(svelteObject.stores)}>Log</button>
 								</I.Array>
 							</div>
 						</div>

--- a/src/routes/example/Number.svelte
+++ b/src/routes/example/Number.svelte
@@ -10,7 +10,7 @@
 	}
 
 	export let value: T = undefined
-	export const store = valueStore<T>(value)
+	export const store = valueStore(value)
 	
 	export let min: number | undefined = undefined
 

--- a/src/routes/example/Text.svelte
+++ b/src/routes/example/Text.svelte
@@ -10,7 +10,7 @@
 	}
 
 	export let value: T = undefined
-	export const store = valueStore<T>(value)
+	export const store = valueStore(value)
 
 	export let 
 		required = false,
@@ -20,7 +20,7 @@
 	const v = {
 		required: {
 			isInvalid: (value: T) => required && (!value || value.length === 0),
-			message: () => `${store.propertyName || 'This input'} is required` as const
+			message: () => `${store.propertyName === undefined ? 'This input' : store.propertyName} is required` as const
 		},
 		min: {
 			isInvalid: (value: T) => min > 0 && (value?.length || 0) !== 0 && (value?.length || 0) < min,

--- a/src/routes/test/+page.svelte
+++ b/src/routes/test/+page.svelte
@@ -15,7 +15,13 @@
 		// store.subscribe(v => console.log(v))
 	})
 
-	/**
+</script>
+
+
+<div>
+	<input use:bind={s} /> {$s}
+</div>
+
 
 	<I.Object id='some-id' let:value>
 		<I.Text name='normal' />
@@ -26,23 +32,11 @@
 
 		<I.Object bind='some-id'>
 			<span>This property parent has `bind="some-id"`</span>
-			<I.Text name='ignore nested' /> <!-- Will be the same property as above component -->
+			<I.Text name='ignore nested'  /> <!-- Will be the same property as above component -->
 		</I.Object>
 
 		<p>{JSON.stringify(value, null, '\t')}</p>
 	</I.Object>
-
-	*/
-
-</script>
-
-
-<div>
-	<input use:bind={s} /> {$s}
-</div>
-
-
-	
 
 <div>
 


### PR DESCRIPTION
feat: callable `valueStore` (aka `ValueStoreFn`) (adds https://github.com/Refzlund/svelte-object/issues/17)
fix: `Object`s `store.validate()` does not run validate nested `valueStore`s (fixes https://github.com/Refzlund/svelte-object/issues/16)
fix: if a valueStore inside an `Array` has index 0, it is not bound (fixes https://github.com/Refzlund/svelte-object/issues/18)